### PR TITLE
genstrap: Include platform firmware in root image

### DIFF
--- a/genstrap.sh
+++ b/genstrap.sh
@@ -74,6 +74,7 @@ cp -r /lib/modules/$(uname -r) lib/modules/
 depmod -a --basedir=. $(uname -r)
 
 cp -r /lib/firmware/brcm/. lib/firmware/brcm/.
+cp -r /lib/firmware/vendor lib/firmware/
 # The squashfs doesn't log in automatically for some reason?
 echo "agetty_options=\"--autologin root\"" >> etc/conf.d/agetty
 sed -i 's/\<agetty\>/& --autologin root/g' etc/inittab
@@ -102,7 +103,6 @@ dracut --force \
     --add-drivers "nvme-apple" \
     --add-drivers "squashfs" \
     --add-drivers "apple-dart" \
-    --add-drivers "brcmfmac" \
     --add "dmsquash-live" \
     --filesystems "squashfs ext4" \
     --include overlay / \


### PR DESCRIPTION
Some firmware files not in the `linux-firmware` package are needed to load a few devices on Apple silicon-based Macs, including the Wi-Fi adapter. Asahi Linux Desktop and Minimal load them to `/lib/firmware/vendor`.  See [1] for more details.

The LiveCD image built by `genstrap.sh` does not load those firmware files, which renders the Wi-Fi adapter unavailable under the LiveCD environment.  See [2] for more details.

This commit will let `genstrap.sh`:
- Copy those firmware files into the LiveCD image
- Allow the image to load the firmware in a manner that is equivalent to what Asahi Linux Desktop and Minimal would do

In particular, the firmware has to be loaded after udev starts according to [1].  Adding the `brcmfmac` driver to the initramfs might cause the firmware to load earlier than udev, which will still trigger Wi-Fi issues as per [2].  Thus, this commit also makes dracut not include the `brcmfmac` driver anymore.

[1]: https://github.com/AsahiLinux/docs/wiki/Open-OS-Ecosystem-on-Apple-Silicon-Macs#firmware-provisioning
[2]: https://leo3418.github.io/2023/01/14/gentoo-asahi-linux.html#fixing-the-genstrapsh-script