### PR TITLE
Increase ramdisk space

### DIFF
--- a/genstrap.sh
+++ b/genstrap.sh
@@ -42,7 +42,7 @@ bsdtar -xf install.iso --include image.squashfs
 echo "Creating temporary mount..."
 echo
 mkdir /mnt/temp
-modprobe brd rd_nr=1 rd_size=1024000
+modprobe brd rd_nr=1 rd_size=1280000
 
 parted -sf /dev/ram0 mklabel gpt
 parted -sf /dev/ram0 "mkpart root 0 -1"


### PR DESCRIPTION
As several have mentioned in #6 I also experienced out of space errors on my recent gentoo install on my M1 mac mini. This should be a sane value that allows for an install, and slightly bigger than needed if Gentoo gets slightly bigger. This should make the process much more seamless for anyone using this project.