### PR TITLE
Adding Asahi Fedora compatibility

### DIFF
--- a/genstrap.sh
+++ b/genstrap.sh
@@ -34,7 +34,7 @@ echo
 cleanup
 
 echo "Installing dependencies..."
-pacman -S --needed squashfs-tools dracut cpio parted
+dnf install -y squashfs-tools dracut cpio parted bsdtar
 
 echo "Extracting squashfs..."
 bsdtar -xf install.iso --include image.squashfs
@@ -113,7 +113,7 @@ dracut --force \
 echo "Setting up initramfs and GRUB..."
 
 mv bootstrap_image.img /boot/initramfs-gentoo-live.img
-cat resources/init_grub >> /boot/grub/grub.cfg
+cat resources/init_grub >> /boot/grub2/grub.cfg
 
 cleanup
 modprobe -r brd

--- a/resources/dracut.conf
+++ b/resources/dracut.conf
@@ -26,3 +26,6 @@ add_drivers+=" apple-dockchannel dockchannel-hid apple-rtkit-helper "
 
 # For Apple firmware
 add_dracutmodules+=" asahi-firmware "
+
+# For Dracut to work with Fedora Asahi (dmsquash-live module isn't available without hostonly set to "no")
+hostonly="no"


### PR DESCRIPTION
I had to change the lines from “pacman -S …” to “dnf install -y …” to gain compatibility for the new Asahi Fedora Remix, which is standard for the Asahi Installer now.

Furthermore, the grub folder is called grub2 in Fedora and for Dracut to call dmsquash-live the parameter “hostonly” needs to get set to “no”.

Greets,
Stuart