### PR TITLE
update dracut configuration and update files to match new kernel config

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -94,7 +94,7 @@ make_kernel() {
                 --force \
                 --quiet \
                 --kver ${KERNVER} \
-                --compress gzip
+                --compress zstd
 
         # We need to rebuild GRUB
         grub-install --removable --efi-directory=/boot --boot-directory=/boot

--- a/resources/dracut-module/install-asahi-firmware.sh
+++ b/resources/dracut-module/install-asahi-firmware.sh
@@ -8,5 +8,5 @@ if [ ! -d /sysroot/lib/firmware/vendor ]; then
     warn ":: Asahi: Vendor firmware directory missing on the root filesystem!"
     return 1
 fi
-mount -t tmpfs vendorfw /sysroot/lib/firmware/vendor
+mount -t tmpfs -o mode=0755 vendorfw /sysroot/lib/firmware/vendor
 cp -pr /vendorfw/* /vendorfw/.vendorfw.manifest /sysroot/lib/firmware/vendor

--- a/resources/dracut-module/module-setup.sh
+++ b/resources/dracut-module/module-setup.sh
@@ -20,7 +20,9 @@ depends() {
 
 # called by dracut
 installkernel() {
-    instmods apple-mailbox nvme-apple
+    # we now build this code in-kernel, not as modules...
+    # ...so we comment out the next line
+    # instmods apple-mailbox nvme-apple vfat
 }
 
 # called by dracut

--- a/resources/dracut.conf
+++ b/resources/dracut.conf
@@ -1,28 +1,13 @@
 # Modules necessary for using Linux on Apple Silicon Macs
 
-# For NVMe & SMC
-add_drivers+=" apple-mailbox "
-
-# For NVMe
-add_drivers+=" nvme_apple "
-
-# For USB and HID
-add_drivers+=" pinctrl-apple-gpio "
-
-# SMC core
-add_drivers+=" macsmc macsmc-rtkit "
-
 # For USB
-add_drivers+=" i2c-apple tps6598x apple-dart dwc3 dwc3-of-simple nvmem-apple-efuses phy-apple-atc xhci-pci pcie-apple gpio_macsmc "
-
-# For HID
-add_drivers+=" spi-apple spi-hid-apple spi-hid-apple-of "
-
-# For RTC
-add_drivers+=" rtc-macsmc simple-mfd-spmi spmi-apple-controller nvmem_spmi_mfd "
+add_drivers+=" dwc3-of-simple phy-apple-atc xhci-plat-hcd xhci-pci "
 
 # For MTP HID
-add_drivers+=" apple-dockchannel dockchannel-hid apple-rtkit-helper "
+add_drivers+=" dockchannel-hid "
+
+# dwc3 instantiates xHCI asynchronously. To make things like init=/bin/sh work where udev is no longer running, force load this one.
+force_drivers+=" xhci-plat-hcd "
 
 # For Apple firmware
 add_dracutmodules+=" asahi-firmware "


### PR DESCRIPTION
In https://github.com/chadmed/asahi-overlay/pull/59 
we propose a new kernel configuration. This has
implications for how dracut needs to be configured, 
as we build more of the Asahi drivers directly into 
the kernel than the previous configuration did.

While we are editing the dracut configuration, we also 
pull in a couple of updates from the upstream 
asahi-scripts that the files come from.
