### PR TITLE
install: preseed required use flags for `dev-lang/rust` or `dev-lang/rust-bin`

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -30,6 +30,8 @@ install_meta() {
 
         [ ! -d /etc/portage/package.mask ] && mkdir /etc/portage/package.mask
         cp resources/package.mask /etc/portage/package.mask/asahi
+        [ ! -d /etc/portage/package.use ] && mkdir /etc/portage/package.use
+        cp resources/package.use /etc/portage/package.use/asahi
         [ ! -d /etc/portage/package.license ] && mkdir /etc/portage/package.license
         echo "sys-kernel/linux-firmware linux-fw-redistributable no-source-code" > /etc/portage/package.license/firmware
 	echo "VIDEO_CARDS=\"asahi\"" >> /etc/portage/make.conf

--- a/resources/package.use
+++ b/resources/package.use
@@ -1,0 +1,2 @@
+dev-lang/rust-bin rustfmt rust-src
+dev-lang/rust rustfmt rust-src


### PR DESCRIPTION
To address possible conflicts while emerging `sys-kernel/asahi-kernel` or `sys-kernel/asahi-sources` while not satisfying required use flags for `dev-lang/rust` or `dev-lang/rust-bin`.

fixes https://github.com/chadmed/asahi-overlay/issues/145